### PR TITLE
update: python 3.13

### DIFF
--- a/basicswap-install.sh
+++ b/basicswap-install.sh
@@ -286,7 +286,7 @@ export MACOS="${MACOS}"
 
 ## Create venv
 if [[ $(type -p uv) ]]; then
-    uv venv -p 3.12 "${SWAP_DATADIR}/venv" --seed
+    uv venv -p ${py_maj}.${py_min} "${SWAP_DATADIR}/venv" --seed
 else
     python3 -m venv "${SWAP_DATADIR}/venv"
 fi

--- a/bsx/shared.sh
+++ b/bsx/shared.sh
@@ -10,6 +10,10 @@ export TOR_DNS_PORT=15353
 export BSX_LOCAL_TOR=true          # sets host to 127.0.0.1
 export BSX_ALLOW_ENV_OVERRIDE=true # required to change the ports
 
+# Python vwrsion
+export py_maj=3
+export py_min=13
+
 # Network
 [[ "${1}${2}${3}${4}${5}" == *"regtest"* ]] && export regtest="--regtest"
 

--- a/bsx/update.sh
+++ b/bsx/update.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+source bsx/shared.sh
 
 # Move scripts
 rm -r $HOME/.local/bin/bsx $HOME/.local/bin/basicswap-*
@@ -7,6 +8,16 @@ cp -r basicswap-bash bsx* $HOME/.local/bin/.
 echo "Updating BasicSwapDEX" && sleep 1
 # Delete dangling build folder. Same as --no-cache for docker
 rm -rf $SWAP_DATADIR/basicswap/build
+
+# Check and update UV python version
+if type -p uv; then
+    cd $SWAP_DATADIR
+    if uv run python -c "import sys; exit(0 if sys.version_info <= (${py_maj},${py_min}) else 1)"; then
+        rm -rf venv
+        green "Updating uv Python to ${py_maj}.${py_min}"
+        uv venv -p ${py_maj}.${py_min} "${SWAP_DATADIR}/venv" --seed
+    fi
+fi
 
 # BasicSwap, coincurve, and dependencies
 # Switch to new repo: basicswap/basicswap


### PR DESCRIPTION
recreate venv if necessary due to minimum python requirements.
bumping to 3.13, even though min is 3.11

confirmed working with 3.13 and 3.14 on ubuntu. arch, and fedora